### PR TITLE
비로그인 시의 토큰 재요청 에러 처리 및 글 작성 후 redirect 경로 변경 

### DIFF
--- a/app/components/Editor.tsx
+++ b/app/components/Editor.tsx
@@ -13,11 +13,10 @@ export default function EditorComponent() {
 
   const handleClick = async () => {
     const contents = editor.getMarkdown();
-    console.log(contents);
     if (!inputTitleRef.current) return;
 
     axiosInstance
-      .post('/articles', {
+      .post('/articles/write', {
         title: inputTitleRef.current.value,
         body: contents,
       })

--- a/app/components/Editor.tsx
+++ b/app/components/Editor.tsx
@@ -22,7 +22,7 @@ export default function EditorComponent() {
       })
       .then((res) => {
         // 글 등록 완료 시, 글 페이지로 리다이렉트
-        router.push(`/articles/${res.data.data.articleId}`);
+        router.push(`/articles/${res.data.data.nickname}/${res.data.data.title}`);
       })
       .catch((err) => {
         console.log(err);

--- a/utils/axios.ts
+++ b/utils/axios.ts
@@ -9,7 +9,11 @@ const axiosInstance = axios.create({
 // 요청 인터셉터
 axiosInstance.interceptors.request.use(
   (config) => {
-    config.headers.Authorization = `Bearer ${getCookie('accessToken')}`;
+    const accessToken = getCookie('accessToken');
+    if (accessToken === undefined) {
+      return config;
+    }
+    config.headers.Authorization = `Bearer ${accessToken}`;
     return config;
   },
   (error) => {
@@ -27,6 +31,7 @@ axiosInstance.interceptors.response.use(
     const errorMsg = error.response.data.code;
     const errorStatus = error.response.status;
 
+    // NO_ACCESS_TOKEN -> reissue X
     // 액세스 토큰 만료시
     if (
       !originalRequest._retry &&


### PR DESCRIPTION
## 🔗 링크(Jira)
https://swm-meteor.atlassian.net/browse/FIN-285
https://swm-meteor.atlassian.net/browse/FIN-284
<br>

## 💬 작업 요약
- 비로그인 시의 토큰 재요청이 발생하는 에러 처리
- 글 작성 후 redirect 경로 변경 
<br>

## 📋 작업 내용
- 비로그인 시 axios Interceptor에서 자동으로 header에 accessToken 을 추가하지 않도록 로직 추가
(SSR 환경에서 cookie값에 접근 불가 -> accessToken이 undefined -> 쿠키값 사용이 필요하면 CSR 페이지로 구축해야 하는 상황)
- 글 작성 성공 시 articleId가 아닌 닉네임/글제목 경로로 리다이렉트되도록 수정
- 글 작성 API endpoint 수정

<br>

## 📷 결과물(스크린샷)

<br>

## 📌 기타(추후 할 일, 의존성있는 작업 등)
