### PR TITLE
닉네임/블로그이름 중복 검사 로직 추가

### DIFF
--- a/app/additional-info/page.tsx
+++ b/app/additional-info/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useForm, SubmitHandler } from 'react-hook-form';
@@ -20,6 +21,8 @@ interface AdditionalInfoType {
 export default function AdditionalInfoPage({ params }: { params: { nickname: string } }) {
   const router = useRouter();
   const { setBlogName } = userBlogNameStore();
+  const [isValidNickname, setIsValidNickname] = useState(true);
+  const [isValidBlogName, setIsValidBlogName] = useState(true);
 
   const {
     register,
@@ -27,6 +30,7 @@ export default function AdditionalInfoPage({ params }: { params: { nickname: str
     watch,
     setError,
     formState: { errors },
+    // errors,
   } = useForm<AdditionalInfoType>();
 
   const onSubmit: SubmitHandler<AdditionalInfoType> = (data) => {
@@ -58,8 +62,20 @@ export default function AdditionalInfoPage({ params }: { params: { nickname: str
             <p className="font-bold text-[14px] mb-[10px]">프로필 이미지</p>
             <ImageUpload register={register} />
           </div>
-          <InputNickname register={register} watch={watch} setError={setError} errors={errors} />
-          <InputBlogName register={register} watch={watch} setError={setError} errors={errors} />
+          <InputNickname
+            register={register}
+            watch={watch}
+            setError={setError}
+            errors={errors}
+            setIsValidNickname={setIsValidNickname}
+          />
+          <InputBlogName
+            register={register}
+            watch={watch}
+            setError={setError}
+            errors={errors}
+            setIsValidBlogName={setIsValidBlogName}
+          />
           <div className="mb-[15px]">
             <CustomButton
               type={'submit'}
@@ -68,6 +84,7 @@ export default function AdditionalInfoPage({ params }: { params: { nickname: str
               fillColor="main"
               textColor="white"
               roundRate={15}
+              isDisabled={!isValidNickname || !isValidBlogName}
             >
               저장하기
             </CustomButton>

--- a/app/additional-info/page.tsx
+++ b/app/additional-info/page.tsx
@@ -24,6 +24,8 @@ export default function AdditionalInfoPage({ params }: { params: { nickname: str
   const {
     register,
     handleSubmit,
+    watch,
+    setError,
     formState: { errors },
   } = useForm<AdditionalInfoType>();
 
@@ -56,8 +58,8 @@ export default function AdditionalInfoPage({ params }: { params: { nickname: str
             <p className="font-bold text-[14px] mb-[10px]">프로필 이미지</p>
             <ImageUpload register={register} />
           </div>
-          <InputNickname register={register} errors={errors} />
-          <InputBlogName register={register} errors={errors} />
+          <InputNickname register={register} watch={watch} setError={setError} errors={errors} />
+          <InputBlogName register={register} watch={watch} setError={setError} errors={errors} />
           <div className="mb-[15px]">
             <CustomButton
               type={'submit'}

--- a/components/AdditionalInfo/InputBlogName.tsx
+++ b/components/AdditionalInfo/InputBlogName.tsx
@@ -1,13 +1,40 @@
-import { UseFormRegister } from 'react-hook-form';
+'use client';
+import { useEffect } from 'react';
+import { UseFormRegister, UseFormWatch, UseFormSetError, FieldErrors } from 'react-hook-form';
 
+import axiosInstance from '@/utils/axios';
 import AdditionalInfoType from '@/types/user';
 
 interface PropsType {
   register: UseFormRegister<AdditionalInfoType>;
-  errors: any;
+  watch: UseFormWatch<AdditionalInfoType>;
+  setError: UseFormSetError<AdditionalInfoType>;
+  errors: FieldErrors<AdditionalInfoType>;
 }
 
-export default function InputBlogName({ register, errors }: PropsType) {
+export default function InputBlogName({ register, watch, setError, errors }: PropsType) {
+  const blogName = watch('blogName');
+
+  useEffect(() => {
+    if (!blogName) return;
+
+    axiosInstance
+      .post('/users/validation/blog-name', { blogName })
+      .then((res) => {
+        if (res.data.data.duplicated) {
+          setError('blogName', {
+            type: 'manual',
+            message: '이 블로그 이름은 이미 사용 중입니다.',
+          });
+        } else {
+          setError('blogName', {}); // 에러 초기화
+        }
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }, [blogName]);
+
   return (
     <div className="mb-[25px]">
       <p className="flex gap-[4px] font-bold text-[14px] mb-[10px]">

--- a/components/AdditionalInfo/InputBlogName.tsx
+++ b/components/AdditionalInfo/InputBlogName.tsx
@@ -10,9 +10,16 @@ interface PropsType {
   watch: UseFormWatch<AdditionalInfoType>;
   setError: UseFormSetError<AdditionalInfoType>;
   errors: FieldErrors<AdditionalInfoType>;
+  setIsValidBlogName: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export default function InputBlogName({ register, watch, setError, errors }: PropsType) {
+export default function InputBlogName({
+  register,
+  watch,
+  setError,
+  errors,
+  setIsValidBlogName,
+}: PropsType) {
   const blogName = watch('blogName');
 
   useEffect(() => {
@@ -34,6 +41,15 @@ export default function InputBlogName({ register, watch, setError, errors }: Pro
         console.log(err);
       });
   }, [blogName]);
+
+  useEffect(() => {
+    console.log(errors.blogName?.message);
+    if (errors.blogName?.message) {
+      setIsValidBlogName(false);
+    } else {
+      setIsValidBlogName(true);
+    }
+  }, [blogName, errors.blogName]);
 
   return (
     <div className="mb-[25px]">

--- a/components/AdditionalInfo/InputNickname.tsx
+++ b/components/AdditionalInfo/InputNickname.tsx
@@ -10,9 +10,16 @@ interface PropsType {
   watch: UseFormWatch<AdditionalInfoType>;
   setError: UseFormSetError<AdditionalInfoType>;
   errors: FieldErrors<AdditionalInfoType>;
+  setIsValidNickname: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export default function InputNickname({ register, watch, setError, errors }: PropsType) {
+export default function InputNickname({
+  register,
+  watch,
+  setError,
+  errors,
+  setIsValidNickname,
+}: PropsType) {
   const nickname = watch('nickname');
 
   useEffect(() => {
@@ -34,6 +41,14 @@ export default function InputNickname({ register, watch, setError, errors }: Pro
         console.log(err);
       });
   }, [nickname]);
+
+  useEffect(() => {
+    if (errors.nickname?.message) {
+      setIsValidNickname(false);
+    } else {
+      setIsValidNickname(true);
+    }
+  }, [nickname, errors.nickname]);
 
   return (
     <div className="mb-[25px]">

--- a/components/AdditionalInfo/InputNickname.tsx
+++ b/components/AdditionalInfo/InputNickname.tsx
@@ -1,13 +1,40 @@
-import { UseFormRegister } from 'react-hook-form';
+'use client';
+import { useEffect } from 'react';
+import { UseFormRegister, UseFormWatch, UseFormSetError, FieldErrors } from 'react-hook-form';
 
+import axiosInstance from '@/utils/axios';
 import AdditionalInfoType from '@/types/user';
 
 interface PropsType {
   register: UseFormRegister<AdditionalInfoType>;
-  errors: any; // object
+  watch: UseFormWatch<AdditionalInfoType>;
+  setError: UseFormSetError<AdditionalInfoType>;
+  errors: FieldErrors<AdditionalInfoType>;
 }
 
-export default function InputNickname({ register, errors }: PropsType) {
+export default function InputNickname({ register, watch, setError, errors }: PropsType) {
+  const nickname = watch('nickname');
+
+  useEffect(() => {
+    if (!nickname) return;
+
+    axiosInstance
+      .post('/users/validation/nickname', { nickname })
+      .then((res) => {
+        if (res.data.data.duplicated) {
+          setError('nickname', {
+            type: 'manual',
+            message: '이 닉네임은 이미 사용 중입니다.',
+          });
+        } else {
+          setError('nickname', {}); // 에러 초기화
+        }
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }, [nickname]);
+
   return (
     <div className="mb-[25px]">
       <p className="flex gap-[4px] font-bold text-[14px] mb-[10px]">


### PR DESCRIPTION
## 🔗 링크(Jira)
https://swm-meteor.atlassian.net/browse/FIN-71
<br>

## 💬 작업 요약
- 추가정보 설정 시 닉네임, 블로그 이름 중복 검사 로직 추가
<br>

## 📋 작업 내용
- 추가정보 설정 시 닉네임, 블로그 이름 중복 검사 로직 추가
- 닉네임, 블로그 조건 만족하지 않을 시 설정 버튼 비활성화
- 중복 검사 호출 로직에 디바운스 적용(0.4초) -> 맨 마지막 입력이 일어나고 0.4초 후에 중복 검사 API 호출


<br>

## 📷 결과물(스크린샷)
<img width="813" alt="image" src="https://github.com/SWM-METEOR/finote-frontend/assets/55318618/42dda2e6-fb23-4619-b557-1aaa55bc59f0">

<br>

## 📌 기타(추후 할 일, 의존성있는 작업 등)
