### PR TITLE
토큰 재발급 API를 동시에 여러번 호출하는 문제 해결

### DIFF
--- a/utils/token.ts
+++ b/utils/token.ts
@@ -11,19 +11,29 @@ interface ReIssueResponse {
   status: number;
 }
 
-export default async function reIssueTokenAndRequestAgain(originalRequest: AxiosRequestConfig) {
-  return await axiosInstance
-    .post<ReIssueResponse>('/users/jwt/re-issue', {
-      accessToken: getCookie('accessToken'),
-      refreshToken: getCookie('refreshToken'),
-    })
-    .then((res) => {
-      // TODO: 구조분해할당
-      const newAccessToken = res.data.data.accessToken;
-      const newRefreshToken = res.data.data.refreshToken;
+let isReissuing = false;
+let reIssuePromise: Promise<any> | null = null;
 
-      setCookie('accessToken', newAccessToken);
-      setCookie('refreshToken', newRefreshToken);
+export default async function reIssueTokenAndRequestAgain(originalRequest: AxiosRequestConfig) {
+  // 이미 토큰 재발급 중인 경우
+  if (isReissuing && reIssuePromise) {
+    await reIssuePromise;
+    originalRequest.headers = originalRequest.headers || {};
+    originalRequest.headers['Authorization'] = 'Bearer ' + getCookie('accessToken');
+    return axiosInstance(originalRequest);
+  }
+
+  isReissuing = true;
+  reIssuePromise = axiosInstance.post<ReIssueResponse>('/users/jwt/re-issue', {
+    accessToken: getCookie('accessToken'),
+    refreshToken: getCookie('refreshToken'),
+  });
+
+  return await reIssuePromise
+    .then((res) => {
+      const { accessToken, refreshToken } = res.data.data;
+      setCookie('accessToken', accessToken);
+      setCookie('refreshToken', refreshToken);
 
       // headers가 존재하는지 확인하고, 없으면 초기화
       if (!originalRequest.headers) {
@@ -31,13 +41,17 @@ export default async function reIssueTokenAndRequestAgain(originalRequest: Axios
       }
 
       // 헤더에 새 토큰 설정
-      originalRequest.headers['Authorization'] = 'Bearer ' + newAccessToken;
+      originalRequest.headers['Authorization'] = 'Bearer ' + accessToken;
 
       // 원래의 요청을 다시 보냄
       return axiosInstance(originalRequest);
     })
     .catch((err) => {
-      console.log(err);
+      console.error(err);
       return Promise.reject(err);
+    })
+    .finally(() => {
+      isReissuing = false;
+      reIssuePromise = null;
     });
 }


### PR DESCRIPTION
## 🔗 링크(Jira)
https://swm-meteor.atlassian.net/browse/FIN-361
<br>

## 💬 작업 요약
- 토큰 재발급 API를 동시에 여러번 호출하는 문제 해결
<br>

## 📋 작업 내용
- `reIssueTokenAndRequestAgain` 함수 안에 중복 재발급 요청 방지 로직 추가

<br>

## 📷 결과물(스크린샷)
- 개선 전
![image (1)](https://github.com/SWM-METEOR/finote-frontend/assets/55318618/4a76cc2c-5eef-4a2a-b2e0-d882c757c635)

- 개선 후
<img width="642" alt="image" src="https://github.com/SWM-METEOR/finote-frontend/assets/55318618/e77ae838-6f01-4e09-81b4-706870e1f924">

<br>

## 📌 기타(추후 할 일, 의존성있는 작업 등)
