### PR TITLE
헤더 프로필 이미지 연동

### DIFF
--- a/components/common/Header/HeaderContainer.tsx
+++ b/components/common/Header/HeaderContainer.tsx
@@ -12,6 +12,7 @@ export default function HeaderContainer() {
   const pathname = usePathname();
   const [accessToken, setAccessToken] = useState<string>('');
   const [nickname, setNickname] = useState('');
+  const [profileImageUrl, setProfileImageUrl] = useState('');
   const { blogName, setBlogName } = userBlogNameStore();
 
   async function getUserNickname() {
@@ -41,6 +42,19 @@ export default function HeaderContainer() {
     }
   }
 
+  async function getUserProfileImage() {
+    if (!accessToken) {
+      return;
+    }
+
+    try {
+      const res = await axiosInstance.get('/users/profile-image-url');
+      setProfileImageUrl(res.data.data.profileImageUrl);
+    } catch (error) {
+      throw new Error('Failed to fetch user profile image');
+    }
+  }
+
   useEffect(() => {
     setAccessToken(getCookie('accessToken') as string);
   }, [pathname]);
@@ -48,12 +62,14 @@ export default function HeaderContainer() {
   useEffect(() => {
     getUserNickname();
     getUserBlogName();
+    getUserProfileImage();
   }, [accessToken]);
 
   return (
     <HeaderView
       nickname={nickname}
       blogName={blogName}
+      profileImageUrl={profileImageUrl}
       accessToken={accessToken}
       pathname={pathname}
     />

--- a/components/common/Header/HeaderView.tsx
+++ b/components/common/Header/HeaderView.tsx
@@ -13,11 +13,18 @@ import MoreShowIcon from '@/components/Icons/MoreShowIcon';
 interface PropsType {
   nickname: string;
   blogName: string;
+  profileImageUrl: string;
   accessToken: string;
   pathname: string;
 }
 
-export default function HeaderView({ nickname, blogName, accessToken, pathname }: PropsType) {
+export default function HeaderView({
+  nickname,
+  blogName,
+  profileImageUrl,
+  accessToken,
+  pathname,
+}: PropsType) {
   const nonHeaderPages = ['/login', '/write', '/edit'];
   const showHeader = !nonHeaderPages.some((page) => pathname.includes(page));
 
@@ -92,8 +99,13 @@ export default function HeaderView({ nickname, blogName, accessToken, pathname }
               >
                 <div className="flex items-center gap-[4px]">
                   <div className="relative w-[30px] h-[30px] rounded-[10px] overflow-hidden flex-shrink-0 bg-main">
-                    {/* TODO: API 추가되고 나서 이미지 연동 필요 */}
-                    <Image fill className="object-cover" src={''} alt={nickname} sizes="100%" />
+                    <Image
+                      fill
+                      className="object-cover"
+                      src={profileImageUrl}
+                      alt={nickname}
+                      sizes="100%"
+                    />
                   </div>
                   <span className="text-[14px] font-medium ml-[4px]">{nickname}</span>
                   <MoreShowIcon width={14} height={14} color="#AAAAAA" />


### PR DESCRIPTION
## 🔗 링크(Jira)
https://swm-meteor.atlassian.net/browse/FIN-379
<br>

## 💬 작업 요약
- 헤더에 프로필 이미지 연동
<br>

## 📋 작업 내용
- 프로필 이미지 URL 불러오는 API 연동 및 이미지 src에 해당 URL 연결

<br>

## 📷 결과물(스크린샷)
<img width="1323" alt="image" src="https://github.com/SWM-METEOR/finote-frontend/assets/55318618/69a95782-5949-445b-8c08-9770f850100b">

<br>

## 📌 기타(추후 할 일, 의존성있는 작업 등)
